### PR TITLE
Update config.example.toml

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,24 +1,26 @@
 [connection]
-host = "localhost"
+host = "agents.amaru.cloud"
 port = 28961
 timeout = "30s"
 keyfile = "/path/to/ssh/priv.key"
 tunnel = true
 
 [application]
-port = 9000
+port = 8080
 hostname = "test.example.com"
 ip = "127.0.0.1"
+
 [application.tags]
-service = "pto"
+service = "application"
 version = "v1.2.3"
 environment = "production"
 region = "us-east-1"
 tier = "backend"
+
 [application.security]
 tls = false
 mtls = false
 
 [logging]
 level = "debug"
-logfile = "/path/to/amaru_agent.log"
+logfile = "/path/to/logs/amaru_agent.log"


### PR DESCRIPTION
Changed the connection host from 'localhost' [makes sense for open source] to default amaru service hostname, which makes more sense given where we want people to use it. I could see `brew` pulling from our fork of the open source agent, with the config biased toward us and the OSS one more generic. For now we should just point to ourselves; anyone trying to deploy this on their own will understand.